### PR TITLE
Improve scroll positioning and content positioning

### DIFF
--- a/examples/example.component.html
+++ b/examples/example.component.html
@@ -229,6 +229,7 @@
             alignContent value :
             <div>
                 <button (click)="alignContent ='left'">left</button>
+                <button (click)="alignContent ='center'">center</button>
                 <button (click)="alignContent ='right'">right</button>
             </div>
             verticalAlignContent value :

--- a/src/walkthrough-container.component.ts
+++ b/src/walkthrough-container.component.ts
@@ -249,11 +249,18 @@ export class WalkthroughContainerComponent extends BasePortalHost {
             if (spaceLeft < width && spaceRight < width) {
                 notEnoughSpace = true;
             }
-            // alignContent center + verticalAlignContent top | center | bottom not compatible
+            // if not enough space to respect the alignContent, content goes above/below
             if ((verticalAlignContent === 'top' ||
                 verticalAlignContent === 'center' ||
                 verticalAlignContent === 'bottom') && !notEnoughSpace) {
-                if (alignContent === 'left' && spaceLeft < width ||
+
+                // change align center to left or right if not enough space to align center
+                if (alignContent === 'center') {
+                    const maxSpace = Math.max(spaceRight, spaceLeft);
+                    if (maxSpace < width + ((window.innerWidth - width) / 2)) {
+                        alignContent = spaceRight > spaceLeft ? 'right' : 'left';
+                    }
+                } else if (alignContent === 'left' && spaceLeft < width ||
                     alignContent === 'right' && spaceRight < width) {
                     verticalAlignContent = verticalAlignContent === 'bottom' || coordinate.top < height ? 'below' : 'above';
                 }

--- a/src/walkthrough.component.ts
+++ b/src/walkthrough.component.ts
@@ -568,7 +568,36 @@ export class WalkthroughComponent implements AfterViewInit {
                         this.ready.emit(new WalkthroughEvent(this, this._focusElement));
                     }
 
-                    this._walkthroughService.scrollIntoViewIfOutOfView(instance.contentBlock.nativeElement);
+                    if (this._focusElement != null) {
+                        const coordinatesContent = this._walkthroughService.retrieveCoordinates(instance.contentBlock.nativeElement);
+                        const coordinatesFocus = this._walkthroughService.retrieveCoordinates(this._focusElement);
+                        // is content + focus higher than window ?
+                        if (coordinatesContent.height + coordinatesFocus.height > window.innerHeight) {
+                            // we scroll on content
+                            instance.contentBlock.nativeElement.scrollIntoView(true);
+                            // we offset the window half of the content height
+                            if (coordinatesContent.top > coordinatesFocus.top) {
+                                // content below focusZone
+                                window.scrollBy(0, -(coordinatesContent.height / 2));
+                            } else {
+                                // content above focusZone
+                                window.scrollBy(0, +(coordinatesContent.height / 2));
+                            }
+                        } else {
+                            // scroll on element higher minus minimal margin
+                            if (coordinatesContent.top > coordinatesFocus.top) {
+                                this._focusElement.scrollIntoView(true);
+                                window.scrollBy(0, -WalkthroughComponent.minimalMargin);
+                            } else {
+                                instance.contentBlock.nativeElement.scrollIntoView(true);
+                                window.scrollBy(0, -WalkthroughComponent.minimalMargin);
+                            }
+                        }
+                    } else {
+                        // no focus zone, scroll on content minus margin
+                        instance.contentBlock.nativeElement.scrollIntoView(true);
+                        window.scrollBy(0, -WalkthroughComponent.minimalMargin);
+                    }
                 }, 50);
             }, 0);
         }


### PR DESCRIPTION
**Improve content positioning**

when `verticalAlignContent = top | center | bottom`

- when there is enough space on the side but we can't respect the `alignContent center` attribute, we rollback to left or right (where there is more space)

**Improve scroll positioning**

- when there is no focus zone, we scroll on the content minus minimal margin (30px)
- when there is focus zone
    - if there is enough height for both focus zone and content, we scroll on the upper element minus minimal margin (30px)
    - if there is not enough height for both focus zone and content, we scroll on the content minus half the height of the content